### PR TITLE
Update Phone validation regex

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -14,7 +14,7 @@ ifdef::env-github[]
 endif::[]
 :repoURL: https://github.com/CS2103-AY1819S1-T13-2/main
 
-By: `Team T13-2`      Since: `Oct 2018`      Licence: `MIT`
+By: `Team T13-2`      Since: `Nov 2018`      Licence: `MIT`
 
 == Introduction
 
@@ -72,7 +72,7 @@ A staff can have any number of tags (including 0)
 Examples:
 
 * `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 d/Accounting m/Marcus Lim t/staff`
-* `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/1234567 d/Marketing m/Edmund Tan t/staff`
+* `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/81729817 d/Marketing m/Edmund Tan t/staff`
 
 === Listing all staff : `list`
 
@@ -379,7 +379,7 @@ _{explain how the user can enable/disable data encryption}_
 == Command Summary
 
 * *Add* `add n/NAME [p]p/PHONE_NUMBER [p]e/EMAIL [p]a/ADDRESS d/DEPARTMENT m/MANAGER [t/TAG]...` +
-e.g. `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 d/Accounting m/David Choo t/staff`
+e.g. `add n/James Ho p/91829309 e/jamesho@example.com a/123, Clementi Rd, 1234665 d/Accounting m/David Choo t/staff`
 * *Clear* : `clear`
 * *Delete* : `delete INDEX` +
 e.g. `delete 3`

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -11,8 +11,9 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+            "Phone numbers should only contain numbers, starts with digit '6', '8' or '9' and it should be 8 digits "
+                    + "long";
+    public static final String VALIDATION_REGEX = "^([6,8-9]{1})([0-9]{7})";
     public final String value;
 
     private final boolean isPrivate;

--- a/src/test/data/XmlAddressBookStorageTest/invalidAndValidPersonAddressBook.xml
+++ b/src/test/data/XmlAddressBookStorageTest/invalidAndValidPersonAddressBook.xml
@@ -3,7 +3,7 @@
     <!-- Valid Person -->
     <persons>
         <name>Hans Muster</name>
-        <phone isPrivate="false">9482424</phone>
+        <phone isPrivate="false">94824241</phone>
         <email isPrivate="false">hans@example.com</email>
         <address isPrivate="false">4th street</address>
     </persons>

--- a/src/test/data/XmlSerializableAddressBookTest/typicalPersonsAddressBook.xml
+++ b/src/test/data/XmlSerializableAddressBookTest/typicalPersonsAddressBook.xml
@@ -63,7 +63,7 @@
     </persons>
     <persons>
         <name>Elle Meyer</name>
-        <phone>9482224</phone>
+        <phone>94822241</phone>
         <email>werner@example.com</email>
         <address>michegan ave</address>
         <rating>0</rating>
@@ -77,7 +77,7 @@
     </persons>
     <persons>
         <name>Fiona Kunz</name>
-        <phone>9482427</phone>
+        <phone>94824271</phone>
         <email>lydia@example.com</email>
         <address>little tokyo</address>
         <rating>0</rating>
@@ -91,7 +91,7 @@
     </persons>
     <persons>
         <name>George Best</name>
-        <phone>9482442</phone>
+        <phone>94824421</phone>
         <email>anna@example.com</email>
         <address>4th street</address>
         <rating>0</rating>

--- a/src/test/data/XmlUtilTest/missingPersonField.xml
+++ b/src/test/data/XmlUtilTest/missingPersonField.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!-- Person with missing name field -->
 <person>
-    <phone>9482424</phone>
+    <phone>94824241</phone>
     <email>hans@example</email>
     <address>4th street</address>
     <rating>0</rating>

--- a/src/test/data/XmlUtilTest/validAddressBook.xml
+++ b/src/test/data/XmlUtilTest/validAddressBook.xml
@@ -2,7 +2,7 @@
 <addressbook>
     <persons>
         <name>Hans Muster</name>
-        <phone isPrivate="false">9482424</phone>
+        <phone isPrivate="false">94824241</phone>
         <email isPrivate="false">hans@example.com</email>
         <address isPrivate="false">4th street</address>
         <rating>0</rating>
@@ -58,7 +58,7 @@
     </persons>
     <persons>
         <name>Werner Meyer</name>
-        <phone isPrivate="false">9482224</phone>
+        <phone isPrivate="false">94822241</phone>
         <email isPrivate="false">werner@example.com</email>
         <address isPrivate="false">michegan ave</address>
         <rating>6</rating>
@@ -72,7 +72,7 @@
     </persons>
     <persons>
         <name>Lydia Kunz</name>
-        <phone isPrivate="false">9482427</phone>
+        <phone isPrivate="false">94824271</phone>
         <email isPrivate="false">lydia@example.com</email>
         <address isPrivate="false">little tokyo</address>
         <rating>5</rating>
@@ -86,7 +86,7 @@
     </persons>
     <persons>
         <name>Anna Best</name>
-        <phone isPrivate="false">9482442</phone>
+        <phone isPrivate="false">94824425</phone>
         <email isPrivate="false">anna@example.com</email>
         <address isPrivate="false">4th street</address>
         <rating>10</rating>
@@ -100,7 +100,7 @@
     </persons>
     <persons>
         <name>Stefan Meier</name>
-        <phone isPrivate="false">8482424</phone>
+        <phone isPrivate="false">84824246</phone>
         <email isPrivate="false">stefan@example.com</email>
         <address isPrivate="false">little india</address>
         <rating>7</rating>
@@ -114,7 +114,7 @@
     </persons>
     <persons>
         <name>Martin Mueller</name>
-        <phone isPrivate="false">8482131</phone>
+        <phone isPrivate="false">84821312</phone>
         <email isPrivate="false">hans@example.com</email>
         <address isPrivate="false">chicago ave</address>
         <rating>5</rating>

--- a/src/test/data/XmlUtilTest/validPerson.xml
+++ b/src/test/data/XmlUtilTest/validPerson.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <person>
     <name>Hans Muster</name>
-    <phone>9482424</phone>
+    <phone>94824241</phone>
     <email>hans@example</email>
     <address>4th street</address>
     <rating>0</rating>

--- a/src/test/java/seedu/address/commons/util/XmlUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/XmlUtilTest.java
@@ -37,7 +37,7 @@ public class XmlUtilTest {
     private static final String INVALID_PHONE = "9482asf424";
 
     private static final String VALID_NAME = "Hans Muster";
-    private static final String VALID_PHONE = "9482424";
+    private static final String VALID_PHONE = "94824241";
     private static final String VALID_EMAIL = "hans@example";
     private static final String VALID_ADDRESS = "4th street";
     private static final String VALID_DEPARTMENT = "Accounting";

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -37,8 +37,8 @@ public class CommandTestUtil {
 
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
-    public static final String VALID_PHONE_AMY = "11111111";
-    public static final String VALID_PHONE_BOB = "22222222";
+    public static final String VALID_PHONE_AMY = "91231234";
+    public static final String VALID_PHONE_BOB = "81231234";
     public static final String VALID_EMAIL_AMY = "amy@example.com";
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -37,7 +37,7 @@ public class ParserUtilTest {
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = "Rachel Walker";
-    private static final String VALID_PHONE = "123456";
+    private static final String VALID_PHONE = "91821289";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_SALARY = "100";

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -68,8 +68,8 @@ public class NameContainsKeywordsPredicateTest {
         assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Keywords match phone, email and address, but does not match name
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("98271821", "alice@email.com", "Main", "Street"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("98271821")
                 .withEmail("alice@email.com").withAddress("Main Street").build()));
     }
 }

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -28,15 +28,16 @@ public class PhoneTest {
         // invalid phone numbers
         assertFalse(Phone.isValidPhone("")); // empty string
         assertFalse(Phone.isValidPhone(" ")); // spaces only
-        assertFalse(Phone.isValidPhone("91")); // less than 3 numbers
+        assertFalse(Phone.isValidPhone("9112312")); // less than 8 numbers
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
+        assertFalse(Phone.isValidPhone("124293842033123")); // long phone numbers
 
         // valid phone numbers
-        assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
         assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("83121534"));
+
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -47,29 +47,29 @@ public class TypicalPersons {
             .withRating("0").withDepartment("Accounting").withManager("Lionel Lim")
             .withSalary("0").withHours("0").withRate("0").withDeductibles("0").withFeedback("-NO FEEDBACK YET-")
             .withTags("friends").build();
-    public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
+    public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("94822241")
             .withEmail("werner@example.com").withAddress("michegan ave").withRating("0")
             .withDepartment("Marketing").withManager("Edward Loh")
             .withSalary("0").withHours("0").withRate("0").withDeductibles("0").withFeedback("-NO FEEDBACK YET-")
             .build();
-    public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
+    public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("94824271")
             .withEmail("lydia@example.com").withAddress("little tokyo").withRating("0")
             .withDepartment("Tech").withManager("Joanne Lee")
             .withSalary("0").withHours("0").withRate("0").withDeductibles("0").withFeedback("-NO FEEDBACK YET-")
             .build();
-    public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
+    public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("94824421")
             .withEmail("anna@example.com").withAddress("4th street").withRating("0")
             .withDepartment("Accounting").withManager("Ben Leong")
             .withSalary("0").withHours("0").withRate("0").withDeductibles("0").withFeedback("-NO FEEDBACK YET-")
             .build();
 
     // Manually added
-    public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
+    public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("84824241")
             .withEmail("stefan@example.com").withAddress("little india").withRating("0")
             .withDepartment("Marketing").withManager("Marcus Tan")
             .withSalary("0").withHours("0").withRate("0").withDeductibles("0").withFeedback("-NO FEEDBACK YET-")
             .build();
-    public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
+    public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("84821311")
             .withEmail("hans@example.com").withAddress("chicago ave").withRating("0")
             .withDepartment("Tech").withManager("Moses Lim")
             .withSalary("0").withHours("0").withRate("0").withDeductibles("0").withFeedback("-NO FEEDBACK YET-")

--- a/src/test/java/seedu/address/ui/PersonListPanelTest.java
+++ b/src/test/java/seedu/address/ui/PersonListPanelTest.java
@@ -96,7 +96,7 @@ public class PersonListPanelTest extends GuiUnitTest {
         for (int i = 0; i < personCount; i++) {
             builder.append("<persons>\n");
             builder.append("<name>").append(i).append("a</name>\n");
-            builder.append("<phone>000</phone>\n");
+            builder.append("<phone>91239090</phone>\n");
             builder.append("<email>a@aa</email>\n");
             builder.append("<address>a</address>\n");
             builder.append("<rating>0</rating>\n");


### PR DESCRIPTION
Now phone field can only have an input that starts with digit '6', '8', '9' and should be 8 digits long.
Fixes #38 
Fixes #82 