### PR TITLE
fix duplicate phone/email problem and edit into same person crash error

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -41,6 +41,8 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in SSENISUB";
+    public static final String MESSAGE_DUPLICATE_PHONE_NUMBER = "This phone number is already in use";
+    public static final String MESSAGE_DUPLICATE_EMAIL = "This email is already in use";
 
     private final Person toAdd;
 
@@ -58,6 +60,14 @@ public class AddCommand extends Command {
 
         if (model.hasPerson(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+
+        if (model.hasPhoneNumber(toAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_PHONE_NUMBER);
+        }
+
+        if (model.hasEmail(toAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_EMAIL);
         }
 
         model.addPerson(toAdd);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -73,7 +73,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in SSENISUB.";
     //public static final String MESSAGE_DUPLICATE_NAME = "Unable to edit to an existing name.";
-    public static final String MESSAGE_DUPLICATE_PHONE_NUMBER = "Unable to edit to a existing phone number";
+    public static final String MESSAGE_DUPLICATE_PHONE_NUMBER = "Unable to edit to an existing phone number";
     public static final String MESSAGE_DUPLICATE_EMAIL = "Unable to edit to an existing email address";
 
     private final Index index;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -72,6 +72,9 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in SSENISUB.";
+    //public static final String MESSAGE_DUPLICATE_NAME = "Unable to edit to an existing name.";
+    public static final String MESSAGE_DUPLICATE_PHONE_NUMBER = "Unable to edit to a existing phone number";
+    public static final String MESSAGE_DUPLICATE_EMAIL = "Unable to edit to an existing email address";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -99,6 +102,14 @@ public class EditCommand extends Command {
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
+
+        if (!personToEdit.hasSamePhone(editedPerson) && model.hasPhoneNumber(editedPerson)) {
+            throw new CommandException(MESSAGE_DUPLICATE_PHONE_NUMBER);
+        }
+
+        if (!personToEdit.hasSameEmail(editedPerson) && model.hasEmail(editedPerson)) {
+            throw new CommandException(MESSAGE_DUPLICATE_EMAIL);
+        }
 
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -24,6 +24,21 @@ public interface Model {
     boolean hasPerson(Person person);
 
     /**
+     * Returns true if a person with the same Name as {@code person} exists in Ssenisub.
+     */
+    boolean hasName(Person person);
+
+    /**
+     * Returns true if a person has the same Phone Number as {@code person} exists in Ssenisub.
+     */
+    boolean hasPhoneNumber(Person person);
+
+    /**
+     * Returns true if a person has the same Email as {@code person} exists in Ssenisub.
+     */
+    boolean hasEmail(Person person);
+
+    /**
      * Deletes the given person.
      * The person must exist in Ssenisub.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -63,6 +63,23 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     @Override
+    public boolean hasName(Person person) {
+        requireNonNull(person);
+        return versionedSsenisub.hasName(person);
+    }
+    @Override
+    public boolean hasPhoneNumber(Person person) {
+        requireNonNull(person);
+        return versionedSsenisub.hasPhoneNumber(person);
+    }
+
+    @Override
+    public boolean hasEmail(Person person) {
+        requireNonNull(person);
+        return versionedSsenisub.hasEmail(person);
+    }
+
+    @Override
     public void deletePerson(Person target) {
         versionedSsenisub.removePerson(target);
         indicateSsenisubChanged();

--- a/src/main/java/seedu/address/model/Ssenisub.java
+++ b/src/main/java/seedu/address/model/Ssenisub.java
@@ -67,6 +67,29 @@ public class Ssenisub implements ReadOnlySsenisub {
     }
 
     /**
+     * Returns true of a person with the same Name as {@code person} exists in Ssenisub.
+     */
+    public boolean hasName(Person person) {
+        requireNonNull(person);
+        return persons.containsName(person);
+    }
+    /**
+     * Returns true if a person with the same Phone Number as {@code person} exists in Ssenisub.
+     */
+    public boolean hasPhoneNumber(Person person) {
+        requireNonNull(person);
+        return persons.containsPhoneNumber(person);
+    }
+
+    /**
+     * Returns true if a person with the same Email as {@code person} exists in Ssenisub.
+     */
+    public boolean hasEmail(Person person) {
+        requireNonNull(person);
+        return persons.containsEmail(person);
+    }
+
+    /**
      * Adds a person to SSENISUB.
      * The person must not already exist in SSENISUB.
      */

--- a/src/main/java/seedu/address/model/Ssenisub.java
+++ b/src/main/java/seedu/address/model/Ssenisub.java
@@ -67,7 +67,7 @@ public class Ssenisub implements ReadOnlySsenisub {
     }
 
     /**
-     * Returns true of a person with the same Name as {@code person} exists in Ssenisub.
+     * Returns true if a person with the same Name as {@code person} exists in Ssenisub.
      */
     public boolean hasName(Person person) {
         requireNonNull(person);

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -117,6 +117,42 @@ public class Person {
     }
 
     /**
+     * Returns true if both persons have the same name.
+     */
+    public boolean hasSameName(Person otherPerson) {
+        if (otherPerson == this) {
+            return true;
+        }
+
+        return otherPerson != null
+                && otherPerson.getName().equals(getName());
+    }
+
+    /**
+     * Returns true if both persons have the same phone number.
+     */
+    public boolean hasSamePhone(Person otherPerson) {
+        if (otherPerson == this) {
+            return true;
+        }
+
+        return otherPerson != null
+                && otherPerson.getPhone().value.equals(getPhone().value);
+    }
+
+    /**
+     * Returns true if both persons have the same email.
+     */
+    public boolean hasSameEmail(Person otherPerson) {
+        if (otherPerson == this) {
+            return true;
+        }
+
+        return otherPerson != null
+                && otherPerson.getEmail().equals(getEmail());
+    }
+
+    /**
      * Returns true if both persons of the same name have at least one other identity field that is the same.
      * This defines a weaker notion of equality between two persons.
      */

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -36,6 +36,29 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
+     * Returns true if the list contains a person with the same Name as the given argument.
+     */
+    public boolean containsName(Person toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::hasSameName);
+    }
+    /**
+     * Returns true if the list contains a person with the same Phone Number as the given argument.
+     */
+    public boolean containsPhoneNumber(Person toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::hasSamePhone);
+    }
+
+    /**
+     * Returns true if the list contains a person with the same Email as the given argument.
+     */
+    public boolean containsEmail(Person toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::hasSameEmail);
+    }
+
+    /**
      * Adds a person to the list.
      * The person must not already exist in the list.
      */

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -109,6 +109,14 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasName(Person person) { throw new AssertionError("This method should not be called."); }
+        @Override
+        public boolean hasPhoneNumber(Person person) { throw new AssertionError("This method should not be called."); }
+
+        @Override
+        public boolean hasEmail(Person person) { throw new AssertionError("This method should not be called."); }
+
+        @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -109,12 +109,19 @@ public class AddCommandTest {
         }
 
         @Override
-        public boolean hasName(Person person) { throw new AssertionError("This method should not be called."); }
-        @Override
-        public boolean hasPhoneNumber(Person person) { throw new AssertionError("This method should not be called."); }
+        public boolean hasName(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
 
         @Override
-        public boolean hasEmail(Person person) { throw new AssertionError("This method should not be called."); }
+        public boolean hasPhoneNumber(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasEmail(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
 
         @Override
         public void deletePerson(Person target) {
@@ -205,6 +212,18 @@ public class AddCommandTest {
         public boolean hasPerson(Person person) {
             requireNonNull(person);
             return personsAdded.stream().anyMatch(person::isSamePerson);
+        }
+
+        @Override
+        public boolean hasPhoneNumber(Person person) {
+            requireNonNull(person);
+            return personsAdded.stream().anyMatch(person::hasSamePhone);
+        }
+
+        @Override
+        public boolean hasEmail(Person person) {
+            requireNonNull(person);
+            return personsAdded.stream().anyMatch(person::hasSameEmail);
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -111,7 +111,7 @@ public class EditCommandTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
 
-        assertCommandFailure(editCommand, model, commandHistory, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model, commandHistory, EditCommand.MESSAGE_DUPLICATE_PHONE_NUMBER);
     }
 
     @Test
@@ -123,7 +123,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder(personInList).build());
 
-        assertCommandFailure(editCommand, model, commandHistory, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model, commandHistory, EditCommand.MESSAGE_DUPLICATE_PHONE_NUMBER);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/FieldsToChangeBuilder.java
+++ b/src/test/java/seedu/address/testutil/FieldsToChangeBuilder.java
@@ -14,7 +14,7 @@ public class FieldsToChangeBuilder {
     }
 
     /**
-     * something
+     * Sets the phone value of the builder to private.
      */
     public FieldsToChangeBuilder withPrivatePhone() {
         fieldsToChange.setPhonePrivacy("Y");
@@ -22,7 +22,7 @@ public class FieldsToChangeBuilder {
     }
 
     /**
-     * something
+     * Sets the email value of the builder to private.
      */
     public FieldsToChangeBuilder withPrivateEmail() {
         fieldsToChange.setEmailPrivacy("Y");
@@ -30,7 +30,7 @@ public class FieldsToChangeBuilder {
     }
 
     /**
-     * something
+     * Sets the address value of the builder to private.
      */
     public FieldsToChangeBuilder withPrivateAddress() {
         fieldsToChange.setAddressPrivacy("Y");
@@ -38,7 +38,7 @@ public class FieldsToChangeBuilder {
     }
 
     /**
-     * something
+     * Sets the phone, email and address value of the builder to private.
      */
     public FieldsToChangeBuilder withAllPrivate() {
         fieldsToChange.setPhonePrivacy("Y");
@@ -48,7 +48,7 @@ public class FieldsToChangeBuilder {
     }
 
     /**
-     * something
+     * Sets the phone, email and address value of the builder to non-private.
      */
     public FieldsToChangeBuilder withNotPrivate() {
         fieldsToChange.setPhonePrivacy("N");
@@ -57,6 +57,10 @@ public class FieldsToChangeBuilder {
         return this;
     }
 
+    /**
+     * Builds the FieldsToChange with the privacy values set.
+     * @return FieldsToChange
+     */
     public FieldsToChange build() {
         return fieldsToChange;
     }

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -23,7 +23,7 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+//import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.TypicalPersons.ALICE;

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -81,11 +81,11 @@ public class AddCommandSystemTest extends SsenisubSystemTest {
         expectedResultMessage = RedoCommand.MESSAGE_SUCCESS;
         assertCommandSuccess(command, model, expectedResultMessage);
 
-        /* Case: add a person with all fields same as another person in SSENISUB except name -> added */
-        toAdd = new PersonBuilder(AMY).withName(VALID_NAME_BOB).build();
-        command = AddCommand.COMMAND_WORD + NAME_DESC_BOB + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + DEPARTMENT_DESC_AMY + MANAGER_DESC_AMY + TAG_DESC_FRIEND;
-        assertCommandSuccess(command, toAdd);
+        ///* Case: add a person with all fields same as another person in SSENISUB except name -> added */
+        //toAdd = new PersonBuilder(AMY).withName(VALID_NAME_BOB).build();
+        //command = AddCommand.COMMAND_WORD + NAME_DESC_BOB + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+        //        + DEPARTMENT_DESC_AMY + MANAGER_DESC_AMY + TAG_DESC_FRIEND;
+        //assertCommandSuccess(command, toAdd);
 
         /* Case: add a person with all fields same as another person in SSENISUB except phone and email
          * -> added

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -102,7 +102,7 @@ public class EditCommandSystemTest extends SsenisubSystemTest {
                 + ADDRESS_DESC_BOB + DEPARTMENT_DESC_BOB + MANAGER_DESC_BOB + TAG_DESC_FRIEND;
         editedPerson = new PersonBuilder(BOB).withName(VALID_NAME_AMY).build();
         assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PHONE_NUMBER);
-//        assertCommandSuccess(command, index, editedPerson);
+        //assertCommandSuccess(command, index, editedPerson);
 
         /* Case: edit a person with new values same as another person's values but with different phone and email
          * -> edited
@@ -144,14 +144,15 @@ public class EditCommandSystemTest extends SsenisubSystemTest {
         /* Case: selects first card in the person list, edit a person -> edited, card selection remains unchanged but
          * browser url changes
          */
-//        showAllPersons();
-//        index = INDEX_FIRST_PERSON;
-//        selectPerson(index);
-//        command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
-//                + ADDRESS_DESC_AMY + DEPARTMENT_DESC_AMY + MANAGER_DESC_AMY + TAG_DESC_FRIEND;
-//        // this can be misleading: card selection actually remains unchanged but the
-//        // browser's url is updated to reflect the new person's name
-//        assertCommandSuccess(command, index, AMY, index);
+        //showAllPersons();
+        //index = INDEX_FIRST_PERSON;
+        //selectPerson(index);
+        //command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_AMY
+        //        + PHONE_DESC_AMY + EMAIL_DESC_AMY
+        //        + ADDRESS_DESC_AMY + DEPARTMENT_DESC_AMY + MANAGER_DESC_AMY + TAG_DESC_FRIEND;
+        // this can be misleading: card selection actually remains unchanged but the
+        // browser's url is updated to reflect the new person's name
+        //assertCommandSuccess(command, index, AMY, index);
 
         /* --------------------------------- Performing invalid edit operation -------------------------------------- */
 

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -43,6 +43,7 @@ import org.junit.Test;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.UndoCommand;
@@ -100,7 +101,8 @@ public class EditCommandSystemTest extends SsenisubSystemTest {
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_AMY + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + DEPARTMENT_DESC_BOB + MANAGER_DESC_BOB + TAG_DESC_FRIEND;
         editedPerson = new PersonBuilder(BOB).withName(VALID_NAME_AMY).build();
-        assertCommandSuccess(command, index, editedPerson);
+        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PHONE_NUMBER);
+//        assertCommandSuccess(command, index, editedPerson);
 
         /* Case: edit a person with new values same as another person's values but with different phone and email
          * -> edited
@@ -142,14 +144,14 @@ public class EditCommandSystemTest extends SsenisubSystemTest {
         /* Case: selects first card in the person list, edit a person -> edited, card selection remains unchanged but
          * browser url changes
          */
-        showAllPersons();
-        index = INDEX_FIRST_PERSON;
-        selectPerson(index);
-        command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
-                + ADDRESS_DESC_AMY + DEPARTMENT_DESC_AMY + MANAGER_DESC_AMY + TAG_DESC_FRIEND;
-        // this can be misleading: card selection actually remains unchanged but the
-        // browser's url is updated to reflect the new person's name
-        assertCommandSuccess(command, index, AMY, index);
+//        showAllPersons();
+//        index = INDEX_FIRST_PERSON;
+//        selectPerson(index);
+//        command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
+//                + ADDRESS_DESC_AMY + DEPARTMENT_DESC_AMY + MANAGER_DESC_AMY + TAG_DESC_FRIEND;
+//        // this can be misleading: card selection actually remains unchanged but the
+//        // browser's url is updated to reflect the new person's name
+//        assertCommandSuccess(command, index, AMY, index);
 
         /* --------------------------------- Performing invalid edit operation -------------------------------------- */
 
@@ -211,44 +213,46 @@ public class EditCommandSystemTest extends SsenisubSystemTest {
                         + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS);
 
         /* Case: edit a person with new values same as another person's values -> rejected */
+        executeCommand(ClearCommand.COMMAND_WORD);
+        executeCommand(PersonUtil.getAddCommand(AMY));
         executeCommand(PersonUtil.getAddCommand(BOB));
         assertTrue(getModel().getSsenisub().getPersonList().contains(BOB));
         index = INDEX_FIRST_PERSON;
         assertFalse(getModel().getFilteredPersonList().get(index.getZeroBased()).equals(BOB));
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + DEPARTMENT_DESC_BOB + MANAGER_DESC_BOB + TAG_DESC_FRIEND;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PHONE_NUMBER);
 
         /* Case: edit a person with new values same as another person's values but with different tags -> rejected */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + DEPARTMENT_DESC_BOB + MANAGER_DESC_BOB + TAG_DESC_HUSBAND;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PHONE_NUMBER);
 
         /* Case: edit a person with new values same as another person's values but with different address -> rejected */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_AMY + DEPARTMENT_DESC_BOB + MANAGER_DESC_BOB + TAG_DESC_FRIEND;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PHONE_NUMBER);
 
         /* Case: edit a person with new values same as another person's values but with different phone -> rejected */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB + PHONE_DESC_AMY + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + DEPARTMENT_DESC_BOB + MANAGER_DESC_BOB + TAG_DESC_FRIEND;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_EMAIL);
 
         /* Case: edit a person with new values same as another person's values but with different email -> rejected */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_AMY
                 + ADDRESS_DESC_BOB + DEPARTMENT_DESC_BOB + MANAGER_DESC_BOB + TAG_DESC_FRIEND;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PHONE_NUMBER);
 
         /* Case: edit a person with new values same as another person's values but with different department ->
         rejected */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB + PHONE_DESC_BOB
                 + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + DEPARTMENT_DESC_AMY + MANAGER_DESC_BOB + TAG_DESC_FRIEND;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PHONE_NUMBER);
 
         /* Case: edit a person with new values same as another person's values but with different manager -> rejected */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB + PHONE_DESC_BOB
                 + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + DEPARTMENT_DESC_BOB + MANAGER_DESC_AMY + TAG_DESC_FRIEND;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PHONE_NUMBER);
     }
 
     /**


### PR DESCRIPTION
add command is now unable to add a person with existing phone or email
edit command is now unable to edit into a existing phone or email

Fixes #84 
Fixes #87 